### PR TITLE
Spring Security 5.7 이후 authorizeRequests의 deprecated에 따른 authorizeHttpRequests로의 메소드 변경

### DIFF
--- a/chapter8/src/main/java/me/shinsunyoung/springbootdeveloper/config/WebSecurityConfig.java
+++ b/chapter8/src/main/java/me/shinsunyoung/springbootdeveloper/config/WebSecurityConfig.java
@@ -37,12 +37,8 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-                .authorizeRequests(auth -> auth
-                        .requestMatchers(
-                                new AntPathRequestMatcher("/login"),
-                                new AntPathRequestMatcher("/signup"),
-                                new AntPathRequestMatcher("/user")
-                        ).permitAll()
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/login", "/signup", "/user").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(formLogin -> formLogin
                         .loginPage("/login")


### PR DESCRIPTION
8장 <스프링 시큐리티로 로그인/로그아웃, 회원 가입 구현하기> 의 시큐리티 설정 파일(/config/WebSecurityConfig.java) 작성 중 HTTP 요청에 대한 보안을 구성하는 filterChain 함수에서, 기존에 작성되어있는 authroizeRequests 메소드가 Spring Security 5.7 버전 이후 deprecated되어 서버 실행시 다음과 같은 에러 메세지가 발생합니다: "...fig/WebSecurityConfig. java uses or overrides a deprecated API." Spring Security 6.2.1 기준으로 authroizeHttpRequests 메소드로 변경하여 다음과 같이 작성하였습니다.
